### PR TITLE
Fix query to not display non-public publications

### DIFF
--- a/app/backend/db_controller/query/publications.py
+++ b/app/backend/db_controller/query/publications.py
@@ -512,7 +512,7 @@ def getPublicationsOfAuthorWithLimit(pub, a_id, limit):
         FROM publications
         JOIN authors_publications ON authors_publications.publication_id = publications.id
         JOIN authors ON authors_publications.author_id = authors.id
-        WHERE publications.id != :pub_id
+        WHERE publications.id != :pub_id AND publications.public = 1
         GROUP BY publications.id
         HAVING agg REGEXP :regex
         ORDER BY ABS(:year - CAST(publications.year AS SIGNED)) ASC


### PR DESCRIPTION
/publications/view showed non-public publications in related publications list.